### PR TITLE
Implement filters for systems' component masks.

### DIFF
--- a/coment/include/coment/EntityInfo.h
+++ b/coment/include/coment/EntityInfo.h
@@ -15,7 +15,7 @@ namespace coment
 		EntityInfo();
 
 		// Compare the bitmask
-		bool compareComponentBitmask(const BitMask& mask) const;
+		bool compareComponentBitmask(const BitMask& mask, const FilterType filter = FILTERTYPE_AND) const;
 
 		// Compare the system bitmask
 		bool compareSystemBitmask(const BitMask& mask) const;

--- a/coment/include/coment/systems/EntitySystem.h
+++ b/coment/include/coment/systems/EntitySystem.h
@@ -75,9 +75,15 @@ namespace coment
 		template <typename T>
 		void registerComponent();
 
+		// Set the filter used for components
+		void setFilter(const FilterType filter);
+
 		// Get the bitmask created from the combination of components
 		// registered with this system
 		BitMask getComponentMask();
+		
+		// Get the filter type to match entities against the component mask
+		FilterType getFilter();
 
 		// Called when an entity is refreshed
 		bool refresh(const EntityInfo& e);
@@ -99,6 +105,9 @@ namespace coment
 
 		// The bitmask to use for the entity system
 		BitMask _bitmask;
+
+		// The filter to use for the entity system
+		FilterType _filter;
 
 		// A bag of entities that match this systems bitmask
 		std::vector<Entity> _entities;

--- a/coment/include/coment/utils/Bitset.h
+++ b/coment/include/coment/utils/Bitset.h
@@ -7,6 +7,7 @@
 #include "../exceptions/NotImplemented.h"
 #include "../exceptions/BitcountOutOfRange.h"
 #include "../exceptions/BitIndexOutOfBounds.h"
+#include "FilterType.h"
 
 namespace coment
 {
@@ -45,6 +46,7 @@ namespace coment
 		void toggleBit(unsigned int index);
 
 		bool isZero() const;
+		bool match(const Bitset<bitcount>& other, const FilterType filter) const;
 
 		void clear();
 
@@ -321,6 +323,20 @@ namespace coment
 		}
 
 		return true;
+	}
+	
+	template <int bitcount>
+	bool Bitset<bitcount>::match(const Bitset<bitcount>& other, const FilterType filter) const
+	{
+		switch (filter)
+		{
+		case FILTERTYPE_AND: // all bits in this must be in other
+			return (((*this) & other) == (*this)); break;
+		case FILTERTYPE_OR: // at least one bit in this must be in other
+			return ((*this) & other).isZero(); break;
+		default:
+			throw NotImplemented();
+		}
 	}
 
 	template <int bitcount>

--- a/coment/include/coment/utils/FilterType.h
+++ b/coment/include/coment/utils/FilterType.h
@@ -1,0 +1,13 @@
+#ifndef COMENT_FILTERTYPE_H
+#define COMENT_FILTERTYPE_H
+
+namespace coment
+{
+	enum FilterType
+	{
+		FILTERTYPE_AND,
+		FILTERTYPE_OR
+	};
+}
+
+#endif /* COMENT_FILTERTYPE_H */

--- a/coment/src/EntityInfo.cpp
+++ b/coment/src/EntityInfo.cpp
@@ -9,9 +9,9 @@ namespace coment
 	}
 
 	// Compare the bitmask
-	bool EntityInfo::compareComponentBitmask(const BitMask& mask) const
+	bool EntityInfo::compareComponentBitmask(const BitMask& mask, const FilterType filter) const
 	{
-		return (mask & _componentMask) == mask;
+		return _systemMask.match(mask, filter);
 	}
 
 	// Compare the system bitmask.

--- a/coment/src/managers/SystemManager.cpp
+++ b/coment/src/managers/SystemManager.cpp
@@ -44,7 +44,7 @@ namespace coment
 		for (unsigned int i = 0; i < _systems.size(); ++i)
 		{
 			// If this entity's components match the system's components
-			if (e.compareComponentBitmask(_systems[i]->getComponentMask()))
+			if (e.compareComponentBitmask(_systems[i]->getComponentMask(), _systems[i]->getFilter()))
 			{
 				// If the entity isn't in the system
 				if (!e.compareSystemBitmask(BitMask(1) << i))

--- a/coment/src/systems/EntitySystem.cpp
+++ b/coment/src/systems/EntitySystem.cpp
@@ -9,7 +9,7 @@ namespace coment
 {
 	// Constructor
 	EntitySystem::EntitySystem()
-		: _world(NULL), _componentTypeManager(NULL), _enabled(true), _firstUpdate(true)
+		: _world(NULL), _componentTypeManager(NULL), _enabled(true), _firstUpdate(true), _filter(FILTERTYPE_AND)
 	{
 
 	}
@@ -74,6 +74,15 @@ namespace coment
 	BitMask EntitySystem::getComponentMask()
 	{
 		return _bitmask;
+	}
+
+	void EntitySystem::setFilter(const FilterType filter)
+	{
+		_filter = filter;
+	}
+	FilterType EntitySystem::getFilter()
+	{
+		return _filter;
 	}
 
 	// Get component type manager


### PR DESCRIPTION
You can now create a system that will run on any entity with
at least one of a set of components (specified with registerComponent<T>
like usual).

Existing code should be 100% compatible (it is implemented with overloads/default arguments throughout).
