### PR TITLE
Added cast to allow for compilers that assign 'unsigned long int' to

### DIFF
--- a/coment/src/managers/TagManager.cpp
+++ b/coment/src/managers/TagManager.cpp
@@ -18,7 +18,7 @@ namespace coment
 	void TagManager::setTag(const EntityInfo& e, std::string tag)
 	{
 		// Grow array to at leasw e.getId() + 1
-		const unsigned int size = std::max(e.getId()+1, _tagsByEntity.size());
+		const unsigned int size = std::max((std::vector<std::string>::size_type)e.getId()+1, _tagsByEntity.size());
 		_tagsByEntity.resize(size);
 
 		// Get old tag


### PR DESCRIPTION
On some machines, size_type is defined as unsigned long int, and since _tagsByEntity.size() returns a variable of type size_type, it can not be compared to e.getId thus will not compile. This pull request adds a simple cast to resolve this issue.
