### PR TITLE
Changed Install to use relative symlinks

### DIFF
--- a/coment/Makefile
+++ b/coment/Makefile
@@ -78,7 +78,8 @@ install:
 	#@ Copy libraries to install directory
 	cp bin/$(REALNAME) $(INSTALL_DIR_LIB)
 	ldconfig -n $(INSTALL_DIR_LIB)
-	ln -sfn $(INSTALL_DIR_LIB)/$(REALNAME) $(INSTALL_DIR_LIB)/$(LINKNAME)
+	cd $(INSTALL_DIR_LIB)
+	ln -sfn $(REALNAME) $(LINKNAME)
 
 uninstall:
 	rm -rf $(INSTALL_DIR_LIB)/libcoment.*


### PR DESCRIPTION
For anyone trying to package this library for use with a package
manager, previously the libcoment.so symlink would not work correctly
once moved to the final location as it was using an absolute reference.
This commit fixes that by creating a relative symlink.
