### PR TITLE
Fixed Makefile to work better with PREFIX

### DIFF
--- a/coment/Makefile
+++ b/coment/Makefile
@@ -77,7 +77,7 @@ install:
 
 	#@ Copy libraries to install directory
 	cp bin/$(REALNAME) $(INSTALL_DIR_LIB)
-	cp bin/$(LINKNAME) $(INSTALL_DIR_LIB)
+	cp -d bin/$(LINKNAME) $(INSTALL_DIR_LIB)
 	ldconfig -n $(INSTALL_DIR_LIB)
 
 uninstall:


### PR DESCRIPTION
When calling "make install" a link called libcoment.so with an absolute
path was being generated. This change uses the relative link
libcoment.so generated during "make shared" and copies it to PREFIX/lib
rather than generating a whole new link.
